### PR TITLE
PPSSE fix & exclude irrelevant files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+* text=auto
+* text eol=lf
+
+tests/ export-ignore
+travis/ export-ignore
+.gitattributes export-ignore
+.travis.yml export-ignore
+build.xml export-ignore
+composer.phar export-ignore
+phpunit.xml.dist export-ignore

--- a/event/listener.php
+++ b/event/listener.php
@@ -24,7 +24,7 @@ class listener implements EventSubscriberInterface
 
 	/** @var \phpbb\user */
 
-	static public function getSubscribedEvents()
+	public static function getSubscribedEvents()
 	{
 		return array(
 			'core.posting_modify_cannot_edit_conditions'	=> 'post_edit',

--- a/migrations/v_1_0_0.php
+++ b/migrations/v_1_0_0.php
@@ -10,7 +10,7 @@ namespace gn36\firstpostedit\migrations;
 
 class v_1_0_0 extends \phpbb\db\migration\migration
 {
-	static public function depends_on()
+	public static function depends_on()
 	{
 		return array();
 	}

--- a/migrations/v_1_1_0.php
+++ b/migrations/v_1_1_0.php
@@ -10,7 +10,7 @@ namespace gn36\firstpostedit\migrations;
 
 class v_1_1_0 extends \phpbb\db\migration\migration
 {
-	static public function depends_on()
+	public static function depends_on()
 	{
 		return array('\gn36\firstpostedit\migrations\v_1_0_0');
 	}

--- a/migrations/v_1_3_0.php
+++ b/migrations/v_1_3_0.php
@@ -10,7 +10,7 @@ namespace gn36\firstpostedit\migrations;
 
 class v_1_3_0 extends \phpbb\db\migration\migration
 {
-	static public function depends_on()
+	public static function depends_on()
 	{
 		return array('\gn36\firstpostedit\migrations\v_1_1_0');
 	}


### PR DESCRIPTION
Hi Martin

* Fix regarding "phpBB PHP Strict Standard Extensions"
* Exclude files that are irrelevant to end users from export.

Reference: https://www.phpbb.de/community/viewtopic.php?p=1426682#p1426682

phpBB Ext Check example:
```
FILE: phpbb-ext-firstpostedit-1.3.0\event\listener.php
--------------------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
--------------------------------------------------------------------------------
 27 | ERROR | Access specifier (e.g. public) should not follow static scope
    |       | attribute. Encountered "public" after static
------------------------------------------------------------
```
